### PR TITLE
PIN im Passport speichern

### DIFF
--- a/src/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -46,26 +46,26 @@ import org.kapott.hbci.manager.HBCIUtilsInternal;
 import org.kapott.hbci.manager.LogFilter;
 import org.kapott.hbci.security.Sig;
 
-/** <p>Passport-Klasse für HBCI mit PIN/TAN. Dieses Sicherheitsverfahren wird erst
-    in FinTS 3.0 spezifiziert, von einigen Banken aber schon mit früheren HBCI-Versionen
+/** <p>Passport-Klasse fÃ¼r HBCI mit PIN/TAN. Dieses Sicherheitsverfahren wird erst
+    in FinTS 3.0 spezifiziert, von einigen Banken aber schon mit frÃ¼heren HBCI-Versionen
     angeboten.</p><p>
     Bei diesem Verfahren werden die Nachrichten auf HBCI-Ebene nicht mit kryptografischen
-    Verfahren signiert oder verschlüsselt. Als "Signatur" werden statt dessen TANs 
+    Verfahren signiert oder verschlÃ¼sselt. Als "Signatur" werden statt dessen TANs 
     zusammen mit einer PIN verwendet. Die PIN wird dabei in <em>jeder</em> HBCI-Nachricht als
-    Teil der "Signatur" eingefügt, doch nicht alle Nachrichten benötigen eine TAN.
-    Eine TAN wird nur bei der Übermittlung bestimmter Geschäftsvorfälle benötigt. Welche
-    GV das konkret sind, ermittelt <em>HBCI4Java</em> automatisch aus den BPD. Für jeden GV, der
-    eine TAN benötigt, wird diese via Callback abgefragt und in die Nachricht eingefügt.</p><p>
-    Die Verschlüsselung der Nachrichten bei der Übertragung erfolgt auf einer höheren
-    Transportschicht. Die Nachrichten werden nämlich nicht direkt via TCP/IP übertragen,
-    sondern in das HTTP-Protokoll eingebettet. Die Verschlüsselung der übertragenen Daten
+    Teil der "Signatur" eingefÃ¼gt, doch nicht alle Nachrichten benÃ¶tigen eine TAN.
+    Eine TAN wird nur bei der Ãœbermittlung bestimmter GeschÃ¤ftsvorfÃ¤lle benÃ¶tigt. Welche
+    GV das konkret sind, ermittelt <em>HBCI4Java</em> automatisch aus den BPD. FÃ¼r jeden GV, der
+    eine TAN benÃ¶tigt, wird diese via Callback abgefragt und in die Nachricht eingefÃ¼gt.</p><p>
+    Die VerschlÃ¼sselung der Nachrichten bei der Ãœbertragung erfolgt auf einer hÃ¶heren
+    Transportschicht. Die Nachrichten werden nÃ¤mlich nicht direkt via TCP/IP Ã¼bertragen,
+    sondern in das HTTP-Protokoll eingebettet. Die VerschlÃ¼sselung der Ã¼bertragenen Daten
     erfolgt dabei auf HTTP-Ebene (via SSL = HTTPS).</p><p>
-    Wie auch bei {@link org.kapott.hbci.passport.HBCIPassportRDH} wird eine "Schlüsseldatei"
-    verwendet. In dieser werden allerdings keine kryptografischen Schlüssel abgelegt, sondern
-    lediglich die Zugangsdaten für den HBCI-Server (Hostadresse, Nutzerkennung, usw.) sowie
-    einige zusätzliche Daten (BPD, UPD, zuletzt benutzte HBCI-Version). Diese Datei wird
-    vor dem Abspeichern verschlüsselt. Vor dem Erzeugen bzw. erstmaligen Einlesen wird via
-    Callback nach einem Passwort gefragt, aus welchem der Schlüssel für die Verschlüsselung
+    Wie auch bei {@link org.kapott.hbci.passport.HBCIPassportRDH} wird eine "SchlÃ¼sseldatei"
+    verwendet. In dieser werden allerdings keine kryptografischen SchlÃ¼ssel abgelegt, sondern
+    lediglich die Zugangsdaten fÃ¼r den HBCI-Server (Hostadresse, Nutzerkennung, usw.) sowie
+    einige zusÃ¤tzliche Daten (BPD, UPD, zuletzt benutzte HBCI-Version). Diese Datei wird
+    vor dem Abspeichern verschlÃ¼sselt. Vor dem Erzeugen bzw. erstmaligen Einlesen wird via
+    Callback nach einem Passwort gefragt, aus welchem der SchlÃ¼ssel fÃ¼r die VerschlÃ¼sselung
     der Datei berechnet wird</p>*/
 public class HBCIPassportPinTan
     extends AbstractPinTanPassport
@@ -150,6 +150,7 @@ public class HBCIPassportPinTan
 
                 setHBCIVersion((String)o.readObject());
                 setCustomerId((String)o.readObject());
+                setPIN((String)o.readObject());
                 setFilterType((String)o.readObject());
                 
                 try {
@@ -169,7 +170,7 @@ public class HBCIPassportPinTan
                     HBCIUtils.log(HBCIUtils.exception2String(e), HBCIUtils.LOG_DEBUG);
                 }
                 
-                // TODO: hier auch gewähltes pintan/verfahren lesen
+                // TODO: hier auch gewÃ¤hltes pintan/verfahren lesen
             } catch (Exception e) {
                 throw new HBCI_Exception("*** loading of passport file failed",e);
             }
@@ -185,8 +186,8 @@ public class HBCIPassportPinTan
         }
     }
     
-    /** Gibt den Dateinamen der Schlüsseldatei zurück.
-        @return Dateiname der Schlüsseldatei */
+    /** Gibt den Dateinamen der SchlÃ¼sseldatei zurÃ¼ck.
+        @return Dateiname der SchlÃ¼sseldatei */
     public String getFileName() 
     {
         return filename;
@@ -238,9 +239,10 @@ public class HBCIPassportPinTan
 
             o.writeObject(getHBCIVersion());
             o.writeObject(getCustomerId());
+            o.writeObject(getPIN());
             o.writeObject(getFilterType());
             
-            // hier auch gewähltes zweischritt-verfahren abspeichern
+            // hier auch gewÃ¤hltes zweischritt-verfahren abspeichern
             List<String> l = getAllowedTwostepMechanisms();
             HBCIUtils.log("saving two step mechs: " + l, HBCIUtils.LOG_DEBUG);
             o.writeObject(l);
@@ -346,7 +348,7 @@ public class HBCIPassportPinTan
 
             if (pintanMethod.equals(Sig.SECFUNC_SIG_PT_1STEP)) {
                 // nur beim normalen einschritt-verfahren muss anhand der segment-
-                // codes ermittelt werden, ob eine tan benötigt wird
+                // codes ermittelt werden, ob eine tan benÃ¶tigt wird
                 HBCIUtils.log("onestep method - checking GVs to decide whether or not we need a TAN",HBCIUtils.LOG_DEBUG);
                 
                 // segment-codes durchlaufen
@@ -358,7 +360,7 @@ public class HBCIPassportPinTan
                     String info=getPinTanInfo(code);
                     
                     if (info.equals("J")) {
-                        // für dieses segment wird eine tan benötigt
+                        // fÃ¼r dieses segment wird eine tan benÃ¶tigt
                         HBCIUtils.log("the job with the code "+code+" needs a TAN",HBCIUtils.LOG_DEBUG);
                         
                         if (tan.length()==0) {
@@ -383,7 +385,7 @@ public class HBCIPassportPinTan
                         
                     } else if (info.length()==0) {
                         // TODO: ist das hier dann nicht ein A-Segment? In dem Fall
-                        // wäre diese Warnung überflüssig
+                        // wÃ¤re diese Warnung Ã¼berflÃ¼ssig
                         HBCIUtils.log("the job with the code "+code+" seems not to be allowed with PIN/TAN",HBCIUtils.LOG_WARN);
                     }
                 }
@@ -485,7 +487,7 @@ public class HBCIPassportPinTan
 
     public boolean verify(byte[] data,byte[] sig)
     {
-        // TODO: fuer bankensignaturen fuer HITAN muss dass hier geändert werden
+        // TODO: fuer bankensignaturen fuer HITAN muss dass hier geÃ¤ndert werden
         return true;
     }
 


### PR DESCRIPTION
Es macht aus meiner Sicht nicht viel Sinn, wenn die PIN nicht im Passport gespeichert wird. Äquivalent zu den anderen Schlüsselmedien, bei denen ausschließlich über die Passphrase auf die privaten Schlüssel zugegriffen wird, habe ich hier zwei Zeilen eingefügt, die die PIN im Passport speichern resp. daraus lesen. Die PIN/TAN-Schlüssel neu zu generieren wegen des geänderten Dateiformats, sollte keine große Hürde sein.
